### PR TITLE
Quiet mode should not ask user if he wants to upload the results. 

### DIFF
--- a/lib/rubygems/commands/test_command.rb
+++ b/lib/rubygems/commands/test_command.rb
@@ -350,7 +350,8 @@ class Gem::Commands::TestCommand < Gem::Command
       config["upload_results"] or
       (
         !config.has_key?("upload_results") and 
-          ask_yes_no("Upload these results?", true)
+        Gem.configuration.verbose == false ||
+        ask_yes_no("Upload these results?", true)
       )
     )
   end

--- a/test/test_execute.rb
+++ b/test/test_execute.rb
@@ -70,4 +70,15 @@ class TestExecute < Test::Unit::TestCase
 
     assert_equal YAML.load(@test.gather_results(spec, output, true)), hash
   end
+
+  def test_07_upload_results?
+    old_verbose = Gem.configuration.verbose
+
+    Gem.configuration.verbose = false
+    assert @test.upload_results?
+
+  ensure
+    Gem.configuration.verbose = old_verbose
+  end
+
 end


### PR DESCRIPTION
"gem test --quiet rubygems-test" or "gem test -q" should not ask user if he wants to upload results. So it is easy to batch test some gems, as:

```
rvm gem test -q rubygems-test
```
